### PR TITLE
Update constant names to snake_case 

### DIFF
--- a/internal/dca/spec.go
+++ b/internal/dca/spec.go
@@ -27,13 +27,13 @@ var supportedChains = []common.Chain{
 }
 
 const (
-	fromChain  = "fromChain"
-	fromAsset  = "fromAsset"
-	fromAmount = "fromAmount"
+	fromChain  = "from_chain"
+	fromAsset  = "from_asset"
+	fromAmount = "from_amount"
 
-	toChain   = "toChain"
-	toAsset   = "toAsset"
-	toAddress = "toAddress"
+	toChain   = "to_chain"
+	toAsset   = "to_asset"
+	toAddress = "to_address"
 )
 
 const (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized DCA configuration keys to snake_case across JSON and runtime configs.
  * Replace: fromChain→from_chain, fromAsset→from_asset, fromAmount→from_amount, toChain→to_chain, toAsset→to_asset, toAddress→to_address.
  * Schema validation and recipe configuration now expect snake_case; update existing configs accordingly. Older camelCase keys are no longer recognized. No behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->