### PR TITLE
Revert "Update constant names to snake_case "

### DIFF
--- a/internal/dca/spec.go
+++ b/internal/dca/spec.go
@@ -27,13 +27,13 @@ var supportedChains = []common.Chain{
 }
 
 const (
-	fromChain  = "from_chain"
-	fromAsset  = "from_asset"
-	fromAmount = "from_amount"
+	fromChain  = "fromChain"
+	fromAsset  = "fromAsset"
+	fromAmount = "fromAmount"
 
-	toChain   = "to_chain"
-	toAsset   = "to_asset"
-	toAddress = "to_address"
+	toChain   = "toChain"
+	toAsset   = "toAsset"
+	toAddress = "toAddress"
 )
 
 const (


### PR DESCRIPTION
Reverts vultisig/dca#2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed configuration keys to camelCase: fromChain, fromAsset, fromAmount, toChain, toAsset, toAddress. Update your configs; snake_case keys are no longer recognized.

- Chores
  - Aligned validation and schema to the new camelCase keys. No changes to app behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->