### PR TITLE
Update required config

### DIFF
--- a/internal/dca/spec.go
+++ b/internal/dca/spec.go
@@ -270,9 +270,11 @@ func (s *Spec) GetRecipeSpecification() (*rtypes.RecipeSchema, error) {
 		"required": []any{
 			frequency,
 			fromChain,
+			fromAsset,
 			fromAmount,
 			fromAddress,
 			toChain,
+			toAsset,
 			toAddress,
 		},
 	})


### PR DESCRIPTION
/suggest endpoint failed because fromAsset and toAssets are  assumed as optional parameters in config
https://github.com/vultisig/dca/blob/main/internal/dca/spec.go#L201
https://github.com/vultisig/dca/blob/main/internal/dca/spec.go#L165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration now requires fromAsset and toAsset when creating DCA recipe specifications. Validation enforces these alongside existing fields (frequency, fromChain, fromAmount, fromAddress, toChain, toAddress) to ensure complete setups.
- Chores
  - Strengthened validation rules for recipe specifications to prevent incomplete configurations. Existing configurations may need updates to include the new asset fields for successful operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->