### PR TITLE
`/suggest` allow asset empty string (native)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.serena

--- a/internal/dca/spec.go
+++ b/internal/dca/spec.go
@@ -153,6 +153,16 @@ func (s *Spec) createSwapMetaRule(cfg map[string]any, fromChainTyped common.Chai
 	toAddressStr := cfg[toAddress].(string)
 	fromAddressStr := cfg[fromAddress].(string)
 
+	var fromAssetStr string
+	if val, ok := cfg[fromAsset]; ok && val != nil {
+		fromAssetStr, _ = val.(string)
+	}
+
+	var toAssetStr string
+	if val, ok := cfg[toAsset]; ok && val != nil {
+		toAssetStr, _ = val.(string)
+	}
+
 	return &rtypes.Rule{
 		Resource: fromChainLowercase + ".swap",
 		Effect:   rtypes.Effect_EFFECT_ALLOW,
@@ -162,7 +172,7 @@ func (s *Spec) createSwapMetaRule(cfg map[string]any, fromChainTyped common.Chai
 				Constraint: &rtypes.Constraint{
 					Type: rtypes.ConstraintType_CONSTRAINT_TYPE_FIXED,
 					Value: &rtypes.Constraint_FixedValue{
-						FixedValue: cfg[fromAsset].(string),
+						FixedValue: fromAssetStr,
 					},
 				},
 			},
@@ -198,7 +208,7 @@ func (s *Spec) createSwapMetaRule(cfg map[string]any, fromChainTyped common.Chai
 				Constraint: &rtypes.Constraint{
 					Type: rtypes.ConstraintType_CONSTRAINT_TYPE_FIXED,
 					Value: &rtypes.Constraint_FixedValue{
-						FixedValue: cfg[toAsset].(string),
+						FixedValue: toAssetStr,
 					},
 				},
 			},


### PR DESCRIPTION
<img width="589" height="683" alt="image" src="https://github.com/user-attachments/assets/a1dd1096-e0cc-49ca-9974-763094775f38" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when reading asset settings in configuration, preventing errors if fields are missing and ensuring safer parameter validation.

* **Chores**
  * Updated ignore list to exclude additional local tooling files for a cleaner repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->