### PR TITLE
chore: make GHCR images public on release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,8 +59,25 @@ jobs:
       tag: ${{ github.event.release.tag_name }}
       additional_tag: latest
 
-  deploy:
+  set-public:
     needs: [build-server, build-scheduler, build-worker, build-tx-indexer]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set GHCR packages public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          owner="${{ github.repository_owner }}"
+          repo="${{ github.event.repository.name }}"
+          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fserver/visibility" -f visibility=public
+          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fscheduler/visibility" -f visibility=public
+          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fworker/visibility" -f visibility=public
+          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Ftx_indexer/visibility" -f visibility=public
+
+  deploy:
+    needs: [build-server, build-scheduler, build-worker, build-tx-indexer, set-public]
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary
- set app-recurring GHCR images to public via API after release publish

## Test plan
- not run (workflow change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment workflow updated with improved orchestration. A new step for container package visibility configuration now executes as part of the deployment sequence, ensuring visibility settings are applied before deployment proceeds. This enhancement optimizes the deployment process and ensures consistent visibility status across all packages during release cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->