### PR TITLE
feat: enable multi-arch Docker builds with GHCR publishing

### DIFF
--- a/.github/workflows/build-push-image.yaml
+++ b/.github/workflows/build-push-image.yaml
@@ -24,15 +24,23 @@ on:
         type: string
         description: Additional tag (e.g., latest, dev-latest)
         default: ""
+      platforms:
+        required: false
+        type: string
+        description: Target platforms (e.g., linux/amd64,linux/arm64)
+        default: "linux/amd64"
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -58,8 +66,10 @@ jobs:
         with:
           context: .
           push: true
+          platforms: ${{ inputs.platforms }}
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
             SERVICE=${{ inputs.service }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM --platform=linux/amd64 golang:1.25.5 AS builder
+FROM golang:1.25.5 AS builder
+
+ARG TARGETARCH
 
 RUN apt-get update && apt-get install -y clang lld wget
 
 RUN wget https://github.com/vultisig/go-wrappers/archive/refs/heads/master.tar.gz && \
     tar -xzf master.tar.gz && \
     cd go-wrappers-master && \
-    mkdir -p /usr/local/lib/dkls && \
-    cp -r includes /usr/local/lib/dkls
+    mkdir -p /usr/local/lib/dkls/includes && \
+    cp includes/go-dkls.h includes/go-schnorr.h /usr/local/lib/dkls/includes/ && \
+    cp -r includes/linux-${TARGETARCH} /usr/local/lib/dkls/includes/linux
 
 ARG SERVICE
 WORKDIR /app
@@ -20,7 +23,7 @@ ENV CGO_LDFLAGS=-fuse-ld=lld
 ENV LD_LIBRARY_PATH=/usr/local/lib/dkls/includes/linux:$LD_LIBRARY_PATH
 RUN go build -o main cmd/${SERVICE}/main.go
 
-FROM --platform=linux/amd64 ubuntu:22.04
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
## Summary
- Update Dockerfile to support linux/amd64 and linux/arm64
- Use TARGETARCH to select correct go-wrappers libraries at build time
- Add QEMU setup for cross-platform builds
- Add platforms input parameter for flexible architecture selection
- Increase build timeout to 30 minutes for multi-arch builds

## Dependencies
⚠️ Requires https://github.com/vultisig/go-wrappers/pull/7 to be merged first

## Test plan
- [ ] Verify amd64 build works
- [ ] Verify arm64 build works (via buildx)
- [ ] Verify GHCR packages are set to public after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build infrastructure to support container images across multiple processor architectures
  * Extended build job timeout to 30 minutes for enhanced reliability
  * Optimized Docker build configuration for better cross-platform compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->