### PR TITLE
fix: add balance check before signing transactions

### DIFF
--- a/internal/btc/network.go
+++ b/internal/btc/network.go
@@ -51,6 +51,19 @@ func (n *Network) Swap(ctx context.Context, policy vtypes.PluginPolicy, from Fro
 		return "", errors.New("can't swap btc to btc")
 	}
 
+	// Check sufficient balance before signing
+	utxos, err := n.FetchUTXOs(ctx, from.Address.String())
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch UTXOs: %w", err)
+	}
+	var totalBalance uint64
+	for _, u := range utxos {
+		totalBalance += u.Value
+	}
+	if totalBalance < from.Amount {
+		return "", fmt.Errorf("insufficient balance: have %d sats, need %d sats", totalBalance, from.Amount)
+	}
+
 	changeOutputIndex, _, outputs, err := n.swap.FindBestAmountOut(ctx, from, to)
 	if err != nil {
 		return "", fmt.Errorf("find best amount out: %w", err)

--- a/internal/evm/balance_service.go
+++ b/internal/evm/balance_service.go
@@ -1,0 +1,53 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	ecommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+
+	evmsdk "github.com/vultisig/recipes/sdk/evm"
+	"github.com/vultisig/recipes/sdk/evm/codegen/erc20"
+)
+
+type balanceService struct {
+	rpc *ethclient.Client
+}
+
+func newBalanceService(rpc *ethclient.Client) *balanceService {
+	return &balanceService{rpc: rpc}
+}
+
+func (s *balanceService) GetNativeBalance(ctx context.Context, address ecommon.Address) (*big.Int, error) {
+	balance, err := s.rpc.BalanceAt(ctx, address, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get native balance: %w", err)
+	}
+	return balance, nil
+}
+
+func (s *balanceService) GetERC20Balance(ctx context.Context, tokenAddress, ownerAddress ecommon.Address) (*big.Int, error) {
+	if tokenAddress == evmsdk.ZeroAddress {
+		return s.GetNativeBalance(ctx, ownerAddress)
+	}
+
+	erc20Contract := erc20.NewErc20()
+
+	balanceOfData := erc20Contract.PackBalanceOf(ownerAddress)
+	balance, err := evmsdk.CallReadonly(
+		ctx,
+		s.rpc,
+		erc20Contract,
+		tokenAddress,
+		balanceOfData,
+		erc20Contract.UnpackBalanceOf,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ERC20 balance: %w", err)
+	}
+
+	return balance, nil
+}

--- a/internal/evm/manager.go
+++ b/internal/evm/manager.go
@@ -16,6 +16,7 @@ type Network struct {
 	SignerSwap *signerService
 	Status     *status.Status
 	Decimals   *decimalsService
+	Balance    *balanceService
 }
 
 type Manager struct {

--- a/internal/evm/network.go
+++ b/internal/evm/network.go
@@ -49,5 +49,6 @@ func NewNetwork(
 		SignerSwap: newSignerService(sdk, chain, signerSwap, txIndexer),
 		Status:     status.NewStatus(rpcCaller),
 		Decimals:   newDecimalsService(rpc),
+		Balance:    newBalanceService(rpc),
 	}, nil
 }

--- a/internal/solana/token_account_service.go
+++ b/internal/solana/token_account_service.go
@@ -145,6 +145,14 @@ func (s *tokenAccountService) BuildCreateATATransaction(
 	return tx, nil
 }
 
+func (s *tokenAccountService) GetNativeBalance(ctx context.Context, account solana.PublicKey) (uint64, error) {
+	balance, err := s.rpcClient.GetBalance(ctx, account, rpc.CommitmentFinalized)
+	if err != nil {
+		return 0, fmt.Errorf("solana: failed to get native balance: %w", err)
+	}
+	return balance.Value, nil
+}
+
 func (s *tokenAccountService) GetTokenBalance(ctx context.Context, tokenAccount solana.PublicKey) (uint64, error) {
 	balance, err := s.rpcClient.GetTokenAccountBalance(ctx, tokenAccount, rpc.CommitmentFinalized)
 	if err != nil {


### PR DESCRIPTION
Previously, transactions were signed and broadcast without first verifying sufficient balance, resulting in wasted TSS signing resources and failed on-chain transactions with "insufficient funds" errors.

This commit adds balance checks before signing for:
- THORChain (RUNE): Check RUNE balance via cosmos bank module
- EVM chains: Check native/ERC20 balance via new balance_service.go
- Bitcoin: Check UTXO total value before building PSBT
- UTXO chains (LTC, DOGE, BCH): Same UTXO balance check
- Solana: Check native SOL and SPL token balances
- Cosmos: Check ATOM balance via cosmos bank module

The balance check happens early in the transaction flow, before any expensive operations like TSS keysigning, preventing unnecessary resource consumption when the transaction would fail anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-flight balance validation across all supported blockchain networks (Bitcoin, Cosmos, Ethereum, Solana, THORChain) to verify sufficient funds before processing transactions and swaps.

* **Bug Fixes**
  * Prevents transaction failures by catching insufficient balance errors before signing and broadcasting operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->