### PR TITLE
fix: copy TaskQueueName from root config to server config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,8 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
+	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
+	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.2 // indirect
 	github.com/bytedance/sonic/loader v0.4.0 // indirect
@@ -265,6 +267,5 @@ replace (
 	github.com/agl/ed25519 => github.com/binance-chain/edwards25519 v0.0.0-20200305024217-f36fc4b53d43
 	github.com/cwespare/xxhash/v2 => github.com/cespare/xxhash/v2 v2.1.1
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
-	github.com/vultisig/verifier => ../verifier
 	nhooyr.io/websocket => github.com/coder/websocket v1.8.6
 )

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
+github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28/ZlunY=
@@ -1009,8 +1010,10 @@ github.com/vultisig/go-wrappers v0.0.0-20260106233302-7e12f0dd6a93 h1:gQr4sjxsRr
 github.com/vultisig/go-wrappers v0.0.0-20260106233302-7e12f0dd6a93/go.mod h1:vEP0x0RmNlghWxfalt13FvVsBwmobSwimMhJxGfqCD4=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/recipes v0.0.0-20260119125552-4c868dfbcba6 h1:2WfVi7AKpI6IbmX8fiFx8Ig9b0u0xPI8OHrhyjK89fo=
-github.com/vultisig/recipes v0.0.0-20260119125552-4c868dfbcba6/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260120151228-f8985632c2e0 h1:AiJ2q7M/18pQn2YiaeClCwUtwoA8ZVDxIDp1lHZJBto=
+github.com/vultisig/recipes v0.0.0-20260120151228-f8985632c2e0/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/verifier v0.1.17-0.20260121062711-4be3fc762923 h1:N4WBKIyyrQauAUtRAkfwiOB77UwLCxnrhecDhBotHlM=
+github.com/vultisig/verifier v0.1.17-0.20260121062711-4be3fc762923/go.mod h1:mC12SLkgLUeD/Rp/GDKx8cnYTMjwiDLl+yQw536eNM4=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110 h1:7WDQ92FAdu08Byjgm3RNS8Sok49sK521PzPcbRpbzCE=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85 h1:NAVXp2Mm791Z/teQHUA8T7mhmx3bouyrXvQkLXvAu3M=


### PR DESCRIPTION
## Summary
- Add `TaskQueueName` field to root config struct with `envconfig:"TASK_QUEUE_NAME"`
- Copy `cfg.TaskQueueName` to `cfg.Server.TaskQueueName` after loading config

## Problem
The server was using the default queue name (`default_queue`) instead of the configured `TASK_QUEUE_NAME` because:
1. The root config didn't have a `TaskQueueName` field
2. The server.Config's `TaskQueueName` field with `envconfig:"SERVER_TASK_QUEUE_NAME"` wasn't being populated via environment variables due to envconfig's nested struct handling

## Impact
In K8s deployments with multiple plugins (verifier + DCA), reshare tasks were being sent to `default_queue` instead of `dca_plugin_queue`, causing the DCA worker to never receive the tasks. This resulted in 4-party reshare only completing with 2 parties (CLI + Fast Vault), missing the Verifier and DCA workers.

## Test plan
- [ ] Deploy to K8s cluster
- [ ] Run `vcli plugin install dca`
- [ ] Verify 4 parties join the reshare (CLI + Fast Vault + Verifier + DCA Worker)
- [ ] Verify both MinIO buckets have keyshares

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task queue name is now configurable to support different deployment scenarios.

* **Chores**
  * Dependency management updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->