### PR TITLE
fix: add TASK_QUEUE_NAME to server deployment

### DIFF
--- a/deploy/base/server/server.yaml
+++ b/deploy/base/server/server.yaml
@@ -96,6 +96,8 @@ spec:
               value: "8088"
             - name: LOGFORMAT
               value: "json"
+            - name: TASK_QUEUE_NAME
+              value: "dca_plugin_queue"
           resources:
             requests:
               memory: "32Mi"


### PR DESCRIPTION
## Summary
- Server was missing `TASK_QUEUE_NAME` env var in deployment config
- This caused reshare tasks to be enqueued to `default_queue` instead of `dca_plugin_queue`
- Worker listens on `dca_plugin_queue`, so reshare tasks were never picked up

## Test plan
- [ ] Deploy updated server config
- [ ] Verify reshare operation works (worker joins the session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server deployment configuration with a new queue-related environment variable to support background task processing capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->