### PR TITLE
tx_indexer: naming fixes for rpc

### DIFF
--- a/deploy/01_tx_indexer.yaml
+++ b/deploy/01_tx_indexer.yaml
@@ -47,7 +47,7 @@ spec:
                 configMapKeyRef:
                   name: rpc
                   key: avalanche
-            - name: BASE_RPC_BSC_URL
+            - name: BASE_RPC_BSCCHAIN_URL
               valueFrom:
                 configMapKeyRef:
                   name: rpc
@@ -102,6 +102,11 @@ spec:
                 configMapKeyRef:
                   name: rpc
                   key: xrp
+            - name: BASE_RPC_SOLANA_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: rpc
+                  key: solana
             - name: BASE_INTERVAL
               value: "30s"
             - name: BASE_ITERATIONTIMEOUT


### PR DESCRIPTION
We've been getting rpc unimplemented for bsc and solana. This is due to errors in the tx_indexer yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Solana blockchain support to the indexer configuration.

* **Chores**
  * Updated environment variable naming for BSC configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->