### PR TITLE
chore: remove auto-deploy, add manual deployment commands

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -11,7 +11,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CLUSTER: plugins-dev-k8s
   NS: plugin-dca
 
 jobs:
@@ -72,13 +71,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_CI_TOKEN }}
-
-      - name: Save DigitalOcean kubeconfig
-        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER }}
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_DEV }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Update deployment files
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: Build and Push Images
 
 on:
   release:
@@ -7,7 +7,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CLUSTER: plugins-prod-k8s
   NS: plugin-dca
 
 jobs:
@@ -76,48 +75,37 @@ jobs:
           gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fworker/visibility" -f visibility=public || true
           gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Ftx_indexer/visibility" -f visibility=public || true
 
-  deploy:
+  update-manifests:
     needs: [build-server, build-scheduler, build-worker, build-tx-indexer, set-public]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
         with:
-          token: ${{ secrets.DIGITALOCEAN_CI_TOKEN }}
+          ref: main
 
-      - name: Save DigitalOcean kubeconfig
-        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER }}
-
-      - name: Update deployment files
+      - name: Update deployment files with new image tags
         run: |
           TAG="${{ github.event.release.tag_name }}"
 
-          sed -i "s|image: busybox|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/server:${TAG}|" deploy/base/server/server.yaml
+          sed -i "s|image: ghcr.io/${{ env.IMAGE_NAME }}/server:.*|image: ghcr.io/${{ env.IMAGE_NAME }}/server:${TAG}|" deploy/base/server/server.yaml
+          sed -i "s|image: busybox|image: ghcr.io/${{ env.IMAGE_NAME }}/server:${TAG}|" deploy/base/server/server.yaml
 
-          sed -i "s|image: busybox|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/scheduler:${TAG}|" deploy/01_scheduler.yaml
-          sed -i "s|image: busybox|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/worker:${TAG}|" deploy/01_worker.yaml
-          sed -i "s|image: busybox|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/tx_indexer:${TAG}|" deploy/01_tx_indexer.yaml
+          sed -i "s|image: ghcr.io/${{ env.IMAGE_NAME }}/scheduler:.*|image: ghcr.io/${{ env.IMAGE_NAME }}/scheduler:${TAG}|" deploy/01_scheduler.yaml
+          sed -i "s|image: busybox|image: ghcr.io/${{ env.IMAGE_NAME }}/scheduler:${TAG}|" deploy/01_scheduler.yaml
 
-      - name: Deploy to Kubernetes
+          sed -i "s|image: ghcr.io/${{ env.IMAGE_NAME }}/worker:.*|image: ghcr.io/${{ env.IMAGE_NAME }}/worker:${TAG}|" deploy/01_worker.yaml
+          sed -i "s|image: busybox|image: ghcr.io/${{ env.IMAGE_NAME }}/worker:${TAG}|" deploy/01_worker.yaml
+
+          sed -i "s|image: ghcr.io/${{ env.IMAGE_NAME }}/tx_indexer:.*|image: ghcr.io/${{ env.IMAGE_NAME }}/tx_indexer:${TAG}|" deploy/01_tx_indexer.yaml
+          sed -i "s|image: busybox|image: ghcr.io/${{ env.IMAGE_NAME }}/tx_indexer:${TAG}|" deploy/01_tx_indexer.yaml
+
+      - name: Commit and push updated manifests
         run: |
-          kubectl -n ${{ env.NS }} apply -f deploy/prod
-
-          kubectl -n ${{ env.NS }} apply -k deploy/overlays/send
-          kubectl -n ${{ env.NS }} apply -k deploy/overlays/swap
-
-          kubectl -n ${{ env.NS }} apply -f deploy/01_scheduler.yaml
-          kubectl -n ${{ env.NS }} apply -f deploy/01_worker.yaml
-          kubectl -n ${{ env.NS }} apply -f deploy/01_tx_indexer.yaml
-
-          kubectl -n ${{ env.NS }} apply -f deploy/02_grafana_dashboard.yaml
-
-          kubectl -n ${{ env.NS }} rollout status deployment/server-send --timeout=300s
-          kubectl -n ${{ env.NS }} rollout status deployment/server-swap --timeout=300s
-          kubectl -n ${{ env.NS }} rollout status deployment/scheduler --timeout=300s
-          kubectl -n ${{ env.NS }} rollout status deployment/worker --timeout=300s
-          kubectl -n ${{ env.NS }} rollout status deployment/tx-indexer --timeout=300s
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add deploy/
+          git commit -m "chore: update image tags to ${{ github.event.release.tag_name }}" || echo "No changes to commit"
+          git push origin main

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: deploy-prod deploy-server-send deploy-server-swap deploy-scheduler deploy-worker deploy-tx-indexer deploy-grafana
+
+NS ?= plugin-dca
+
+deploy-prod: deploy-configs deploy-server-send deploy-server-swap deploy-scheduler deploy-worker deploy-tx-indexer deploy-grafana
+
+deploy-configs:
+	kubectl -n $(NS) apply -f deploy/prod
+
+deploy-server-send:
+	kubectl -n $(NS) apply -k deploy/overlays/send
+	kubectl -n $(NS) rollout status deployment/server-send --timeout=300s
+
+deploy-server-swap:
+	kubectl -n $(NS) apply -k deploy/overlays/swap
+	kubectl -n $(NS) rollout status deployment/server-swap --timeout=300s
+
+deploy-scheduler:
+	kubectl -n $(NS) apply -f deploy/01_scheduler.yaml
+	kubectl -n $(NS) rollout status deployment/scheduler --timeout=300s
+
+deploy-worker:
+	kubectl -n $(NS) apply -f deploy/01_worker.yaml
+	kubectl -n $(NS) rollout status deployment/worker --timeout=300s
+
+deploy-tx-indexer:
+	kubectl -n $(NS) apply -f deploy/01_tx_indexer.yaml
+	kubectl -n $(NS) rollout status deployment/tx-indexer --timeout=300s
+
+deploy-grafana:
+	kubectl -n $(NS) apply -f deploy/02_grafana_dashboard.yaml


### PR DESCRIPTION
## Summary
- Remove DigitalOcean doctl and auto-deploy from CI workflow (removes `secrets.DIGITALOCEAN_CI_TOKEN` usage)
- CI now only builds/pushes images and updates manifests with new tags
- Add Makefile with `kubectl apply` commands for manual deployment

## Changes
- `.github/workflows/deploy.yaml`: Removed deploy job, added update-manifests job
- `Makefile`: New file with `deploy-prod`, `deploy-server-send`, `deploy-server-swap`, `deploy-scheduler`, `deploy-worker`, `deploy-tx-indexer`, `deploy-grafana` commands

## Test plan
- [ ] Verify CI workflow builds images correctly on release
- [ ] Verify CI workflow updates manifests with new tags
- [ ] Verify `make deploy-prod` works from local machine with kubectl access

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to use manifest-based deployments committed to the main branch instead of direct Kubernetes operations.
  * Introduced a Makefile for centralized management of deployment targets across multiple services.
  * Modernized kubeconfig handling in the development deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->