### PR TITLE
ci: trigger deploy-dev workflow after sync-main-to-dev

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - '**.md'
       - '.gitignore'
+  workflow_run:
+    workflows: ["Sync main to dev"]
+    types:
+      - completed
 
 env:
   REGISTRY: ghcr.io
@@ -15,6 +19,9 @@ env:
 
 jobs:
   build-server:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/build-push-image.yaml
     permissions:
       contents: read
@@ -23,10 +30,13 @@ jobs:
       service: server
       registry: ghcr.io
       image_name: ${{ github.repository }}
-      tag: dev-${{ github.sha }}
+      tag: dev-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       additional_tag: dev-latest
 
   build-scheduler:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/build-push-image.yaml
     permissions:
       contents: read
@@ -35,10 +45,13 @@ jobs:
       service: scheduler
       registry: ghcr.io
       image_name: ${{ github.repository }}
-      tag: dev-${{ github.sha }}
+      tag: dev-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       additional_tag: dev-latest
 
   build-worker:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/build-push-image.yaml
     permissions:
       contents: read
@@ -47,10 +60,13 @@ jobs:
       service: worker
       registry: ghcr.io
       image_name: ${{ github.repository }}
-      tag: dev-${{ github.sha }}
+      tag: dev-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       additional_tag: dev-latest
 
   build-tx-indexer:
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/build-push-image.yaml
     permissions:
       contents: read
@@ -59,7 +75,7 @@ jobs:
       service: tx_indexer
       registry: ghcr.io
       image_name: ${{ github.repository }}
-      tag: dev-${{ github.sha }}
+      tag: dev-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       additional_tag: dev-latest
 
   deploy:
@@ -70,6 +86,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && 'dev' || github.ref }}
 
       - name: Set up kubeconfig
         run: |
@@ -79,7 +97,7 @@ jobs:
 
       - name: Update deployment files
         run: |
-          TAG="dev-${{ github.sha }}"
+          TAG="dev-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}"
 
           sed -i "s|image: busybox|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/server:${TAG}|" deploy/base/server/server.yaml
 


### PR DESCRIPTION
## Summary
- Add `workflow_run` trigger to `deploy-dev.yaml` so it triggers when `sync-main-to-dev` completes successfully
- Fix SHA references to use correct commit when triggered via workflow_run
- This fixes the issue where pushes via GITHUB_TOKEN don't trigger other workflows

## Test plan
- [ ] Merge to main and verify deploy-dev triggers after sync-main-to-dev completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow automation with enhanced coordination between workflows, ensuring consistent and reliable deployment execution.
  * Refined image tagging mechanism to dynamically select deployment identifiers based on trigger source, supporting both direct pushes and workflow-initiated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->